### PR TITLE
feat: add defineVariable, addModule, asExpression helpers

### DIFF
--- a/src/configBuilder.test.ts
+++ b/src/configBuilder.test.ts
@@ -44,13 +44,16 @@ describe("configBuilder", () => {
 
         describe("should do nothing if", () => {
             it("prompts are empty", () => {
-                configBuilder.handleGeneralQuestions([], [jest.fn()], false);
+                configBuilder.handleGeneralQuestions([], [jest.fn()], { path: "/", noQuestions: false });
 
                 expectConfig(defaultHermioneConfig);
             });
 
             it("handlers are empty", () => {
-                configBuilder.handleGeneralQuestions([{ message: "foo", type: "input", name: "bar" }], [], false);
+                configBuilder.handleGeneralQuestions([{ message: "foo", type: "input", name: "bar" }], [], {
+                    path: "/",
+                    noQuestions: false,
+                });
 
                 expectConfig(defaultHermioneConfig);
             });
@@ -64,7 +67,7 @@ describe("configBuilder", () => {
                     { message: "second silent question", type: "input", name: "3", default: "42" },
                 ],
                 [jest.fn()],
-                true,
+                { path: "/", noQuestions: true },
             );
 
             expect(inquirer.prompt).toBeCalledWith([{ message: "loud question", type: "input", name: "2" }]);
@@ -85,7 +88,10 @@ describe("configBuilder", () => {
 
             when(inquirer.prompt).calledWith(questions).mockResolvedValue(answers);
 
-            configBuilder.handleGeneralQuestions(questions, [firstHandler, secondHandler], false);
+            configBuilder.handleGeneralQuestions(questions, [firstHandler, secondHandler], {
+                path: "/",
+                noQuestions: false,
+            });
         });
     });
 

--- a/src/configBuilder.ts
+++ b/src/configBuilder.ts
@@ -22,7 +22,7 @@ export class ConfigBuilder {
     async handleGeneralQuestions(
         promts: GeneralPrompt[],
         handlers: HandleGeneralPromptsCallback[],
-        noQuestions: boolean,
+        { path, noQuestions }: { path: string; noQuestions: boolean },
     ): Promise<void> {
         if (_.isEmpty(promts) || _.isEmpty(handlers)) {
             return;
@@ -39,6 +39,8 @@ export class ConfigBuilder {
         const promptsToAsk = noQuestions ? promts.filter(prompt => _.isUndefined(prompt.default)) : promts;
         const inquirerAnswers = await inquirer.prompt(promptsToAsk);
         const answers = noQuestions ? { ...defaults, ...inquirerAnswers } : inquirerAnswers;
+
+        answers._path = path;
 
         for (const handler of handlers) {
             this._config = await handler(this._config, answers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ process.on("unhandledRejection", (reason, p) => {
     console.error("Unhandled Rejection:\n  Promise: ", p, "\n  Reason: ", reason);
 });
 
-export { askQuestion } from "./utils";
+export { askQuestion, defineVariable, addModule, asExpression } from "./utils";
 export { baseGeneralPrompts };
 
 export const run = async ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export const run = async ({
         ? [baseGeneralPromptsHandler, generalPromptsHandler]
         : [baseGeneralPromptsHandler];
 
-    await configBuilder.handleGeneralQuestions(generalPrompts, generalPromptsHandlers, opts.noQuestions);
+    await configBuilder.handleGeneralQuestions(generalPrompts, generalPromptsHandlers, opts);
 
     const { pluginNames, configNotes } = await getPluginNames(opts);
     const extraPackages = getExtraPackagesToInstall ? getExtraPackagesToInstall() : { names: [], notes: [] };

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -138,4 +138,34 @@ describe("utils", () => {
 
         expect(fsUtils.writeTest).toBeCalledWith("/foo", "example.hermione.js", expect.anything());
     });
+
+    describe("defineVariable", () => {
+        it("should set string variable", () => {
+            const config = {} as HermioneConfig;
+
+            utils.defineVariable(config, { name: "foo", value: "ba'r" });
+
+            expect(config).toStrictEqual({ __variables: { foo: "'ba\\'r'" } });
+        });
+
+        it("should set expr variable", () => {
+            const config = {} as HermioneConfig;
+
+            utils.defineVariable(config, { name: "foo", value: "bar", isExpr: true });
+
+            expect(config).toStrictEqual({ __variables: { foo: "bar" } });
+        });
+    });
+
+    it("addModule", () => {
+        const config = {} as HermioneConfig;
+
+        utils.addModule(config, "foo", "bar");
+
+        expect(config).toStrictEqual({ __modules: { foo: "bar" } });
+    });
+
+    it("asExpression", () => {
+        expect(utils.asExpression("foo")).toBe("__expression: foo");
+    });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ import fsUtils from "../fsUtils";
 import type { ConfigNote } from "../plugins";
 import type { ToolArgv } from "../types/toolArgv";
 import type { ArgvOpts, HandleGeneralPromptsCallback } from "../types/toolOpts";
+import type { HermioneConfig } from "../types";
 
 export const optsFromArgv = (argv: ToolArgv): ArgvOpts => {
     if (!argv["_"].length) {
@@ -121,3 +122,21 @@ describe('test', () => {
 
     await fsUtils.writeTest(dirPath, "example.hermione.js", testExample);
 };
+
+const asString = (str: string): string => `'${str.replace(/'/gi, "\\'")}'`;
+
+type VariableOpts = {
+    name: string;
+    value: string;
+    isExpr?: boolean;
+};
+
+export const defineVariable = (config: HermioneConfig, { name, value, isExpr }: VariableOpts): HermioneConfig => {
+    return _.set(config, ["__variables", name], isExpr ? value : asString(value));
+};
+
+export const addModule = (config: HermioneConfig, variableName: string, moduleName = variableName): HermioneConfig => {
+    return _.set(config, ["__modules", variableName], moduleName);
+};
+
+export const asExpression = (value: string): string => `__expression: ${value}`;


### PR DESCRIPTION
## Что сделано
Добавил функций `addModule`, `defineVariable`, `asExpression`, чтобы в пакетах, использующих этот пакет, не нужно было завязываться на названия этих полей:
- `addModule` - импортирует модуль (типа `path`, `os`, `fs`)
- `defineVariable` - объявляет переменную
- `asExpression` - превращает в конфиге значение типа `"process.env.CI"` в `process.env.CI` (превращает строку в не-строку)

Докинул `_path` в объект с ответами, чтобы обработчики могли узнать, в какой папке разворачивается проект (начинается с `_` на всякий случай, чтобы избежать коллизий)