### PR TITLE
fix: create-hermione-app rebranding fixups

### DIFF
--- a/__fixtures/config/jsConfig.js
+++ b/__fixtures/config/jsConfig.js
@@ -1,6 +1,6 @@
 module.exports = {
-    gridUrl: "http://localhost:4444/wd/hub",
-    baseUrl: "http://localhost",
+    gridUrl: 'http://localhost:4444/wd/hub',
+    baseUrl: 'http://localhost',
     pageLoadTimeout: 0,
     httpTimeout: 60000,
     testTimeout: 90000,
@@ -8,19 +8,19 @@ module.exports = {
     sets: {
         desktop: {
             files: [
-                "testplane-tests/**/*.testplane.(t|j)s"
+                'testplane-tests/**/*.testplane.(t|j)s'
             ],
             browsers: [
-                "chrome"
+                'chrome'
             ]
         }
     },
     browsers: {
         chrome: {
-            automationProtocol: "devtools",
+            automationProtocol: 'devtools',
             headless: true,
             desiredCapabilities: {
-                browserName: "chrome"
+                browserName: 'chrome'
             }
         }
     }

--- a/__fixtures/config/withComments.js
+++ b/__fixtures/config/withComments.js
@@ -3,7 +3,7 @@ module.exports = {
     // other comment
     array: [
         // array comment
-        "some string",
+        'some string',
         // another comment
     ]
 };

--- a/__fixtures/config/withEverything.js
+++ b/__fixtures/config/withEverything.js
@@ -3,8 +3,7 @@ import path from "path";
 
 const isCi = Boolean(process.env.CI);
 
-// @ts-ignore
-export = {
+export default {
     gridUrl: "http://localhost:4444/wd/hub",
     baseUrl: "http://localhost",
     pageLoadTimeout: 0,

--- a/__fixtures/config/withEverything.js
+++ b/__fixtures/config/withEverything.js
@@ -31,7 +31,7 @@ export = {
         }
     },
     plugins: {
-        "hermione-oauth": {
+        "@testplane/oauth": {
             // some info
             enabled: isCi,
             token: path.join(os.homedir(), ".config", "tokens", "token")

--- a/__fixtures/config/withExpressions.js
+++ b/__fixtures/config/withExpressions.js
@@ -1,7 +1,7 @@
 module.exports = {
     foo: Boolean(100 + 500 * 1),
     bar: 4,
-    baz: "4",
+    baz: '4',
     array: [
         Boolean(100 + 500 * 1)
     ],

--- a/__fixtures/config/withModules.js
+++ b/__fixtures/config/withModules.js
@@ -1,5 +1,5 @@
-const os = require("os");
-const path = require("path");
-const fs = require("fs");
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
 module.exports = {};

--- a/__fixtures/config/withTypescript.js
+++ b/__fixtures/config/withTypescript.js
@@ -2,5 +2,4 @@ import os from "os";
 import path from "path";
 import fs from "fs";
 
-// @ts-ignore
-export = {};
+export default {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "create-hermione-app",
+    "name": "create-testplane",
     "version": "0.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "create-hermione-app",
-            "version": "1.1.2",
+            "name": "create-testplane",
+            "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
                 "inquirer": "^8.2.4",
@@ -15,7 +15,7 @@
                 "yargs": "^17.5.1"
             },
             "bin": {
-                "create-hermione-app": "build/bin/create-hermione-app.js"
+                "create-testplane": "build/bin/create-testplane.js"
             },
             "devDependencies": {
                 "@commitlint/cli": "^16.3.0",

--- a/src/configBuilder.test.ts
+++ b/src/configBuilder.test.ts
@@ -105,22 +105,17 @@ describe("configBuilder", () => {
 
         it("should use default pluginsConfig, if not specified", async () => {
             const generalAnswers: Answers = { _path: "/", _language: "ts" };
-            defaultPluginsConfig["html-reporter/testplane"] = jest
-                .fn()
-                .mockImplementation((config: TestplaneConfig) => {
-                    _.set(config, "htmlReporterIsSet", true);
-                });
+            defaultPluginsConfig["html-reporter"] = jest.fn().mockImplementation((config: TestplaneConfig) => {
+                _.set(config, "htmlReporterIsSet", true);
+            });
 
             await configBuilder.configurePlugins({
-                pluginNames: ["html-reporter/testplane"],
+                pluginNames: ["html-reporter"],
                 generalAnswers,
             });
 
             expectConfig({ ...defaultTestplaneConfig, htmlReporterIsSet: true });
-            expect(defaultPluginsConfig["html-reporter/testplane"]).toBeCalledWith(
-                defaultTestplaneConfig,
-                generalAnswers,
-            );
+            expect(defaultPluginsConfig["html-reporter"]).toBeCalledWith(defaultTestplaneConfig, generalAnswers);
         });
 
         it("should use overwrited pluginsConfig, if specified", async () => {
@@ -129,13 +124,13 @@ describe("configBuilder", () => {
             when(cb)
                 .calledWith(defaultPluginsConfig)
                 .mockReturnValue({
-                    "html-reporter/testplane": (config: TestplaneConfig) => {
+                    "html-reporter": (config: TestplaneConfig) => {
                         _.set(config, "foo", "bar");
                     },
                 });
 
             await configBuilder.configurePlugins({
-                pluginNames: ["html-reporter/testplane"],
+                pluginNames: ["html-reporter"],
                 createPluginsConfig: cb,
                 generalAnswers: { _path: "/", _language: "ts" },
             });

--- a/src/configBuilder.test.ts
+++ b/src/configBuilder.test.ts
@@ -105,9 +105,11 @@ describe("configBuilder", () => {
 
         it("should use default pluginsConfig, if not specified", async () => {
             const generalAnswers: Answers = { _path: "/", _language: "ts" };
-            defaultPluginsConfig["html-reporter/testplane"] = jest.fn().mockImplementation((config: TestplaneConfig) => {
-                _.set(config, "htmlReporterIsSet", true);
-            });
+            defaultPluginsConfig["html-reporter/testplane"] = jest
+                .fn()
+                .mockImplementation((config: TestplaneConfig) => {
+                    _.set(config, "htmlReporterIsSet", true);
+                });
 
             await configBuilder.configurePlugins({
                 pluginNames: ["html-reporter/testplane"],

--- a/src/constants/packageManagement.ts
+++ b/src/constants/packageManagement.ts
@@ -1,6 +1,11 @@
 export const PACKAGE_JSON = "package.json";
-export const TESTPLANE_JS_CONFIG_NAME = ".testplane.conf.js";
-export const TESTPLANE_TS_CONFIG_NAME = ".testplane.conf.ts";
+
+export const CONFIG_NAMES = {
+    TESTPLANE_TS: ".testplane.conf.ts",
+    TESTPLANE_JS: ".testplane.conf.js",
+    HERMIONE_TS: ".hermione.conf.ts", // drop after testplane@1
+    HERMIONE_JS: ".hermione.conf.js", // drop after testplane@1
+} as const;
 
 export const DEFAULT_PM = "npm";
 

--- a/src/constants/packageManagement.ts
+++ b/src/constants/packageManagement.ts
@@ -24,4 +24,4 @@ export const PMS: Record<PackageManager, { lock: string; init: string; install: 
     },
 };
 
-export const pluginSuffixes = ["/plugin", "/testplane"];
+export const pluginSuffixes = ["/plugin", "/testplane", "/hermione"]; // drop hermione suffix after testplane@1

--- a/src/constants/plugins.ts
+++ b/src/constants/plugins.ts
@@ -1,4 +1,4 @@
-export const HTML_REPORTER = "html-reporter/testplane";
+export const HTML_REPORTER = "html-reporter";
 export const TESTPLANE_TEST_REPEATER = "@testplane/test-repeater";
 export const TESTPLANE_RETRY_COMMAND = "@testplane/retry-command";
 export const TESTPLANE_REASSERT_VIEW = "@testplane/reassert-view";

--- a/src/fsUtils.test.ts
+++ b/src/fsUtils.test.ts
@@ -55,7 +55,7 @@ describe("fsUtils", () => {
                 ...jsTemplate,
                 __comment: "some comment",
                 __comment4: "other comment",
-                array: ["__comment: array comment", "some stirng", "__comment: another comment"],
+                array: ["__comment: array comment", "some string", "__comment: another comment"],
             } as unknown as TestplaneConfig;
 
             await expectConfig(withCommentsConfig, configs["withComments"]);

--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -1,0 +1,29 @@
+import fsUtils from "./fsUtils";
+import { initApp } from "./package";
+
+jest.mock("child_process");
+jest.mock("./fsUtils");
+jest.mock("./utils");
+
+describe("package", () => {
+    beforeEach(() => {
+        jest.spyOn(console, "error").mockImplementation(jest.fn);
+        jest.spyOn(process, "exit").mockImplementation(jest.fn as never);
+    });
+
+    describe("initApp", () => {
+        [".testplane.conf.ts", ".testplane.conf.js", ".hermione.conf.ts", ".hermione.conf.js"].forEach(configName => {
+            it(`should throw an error, if ${configName} exists`, async () => {
+                const dirPath = "/dir/path";
+                jest.mocked(fsUtils.exists).mockImplementation(file =>
+                    Promise.resolve([`${dirPath}/${configName}`, `${dirPath}/package.json`].includes(file)),
+                );
+
+                await initApp(dirPath, true);
+
+                expect(console.error).toBeCalledWith(`Looks like ${dirPath} already contains "${configName}".`);
+                expect(process.exit).toBeCalledWith(1);
+            });
+        });
+    });
+});

--- a/src/utils/configTemplates/js.ts
+++ b/src/utils/configTemplates/js.ts
@@ -1,8 +1,8 @@
 import { ConfigTemplate } from ".";
-import { TESTPLANE_JS_CONFIG_NAME } from "../../constants/packageManagement";
+import { CONFIG_NAMES } from "../../constants/packageManagement";
 
 export const jsTemplate: ConfigTemplate = {
-    fileName: TESTPLANE_JS_CONFIG_NAME,
+    fileName: CONFIG_NAMES.TESTPLANE_JS,
     language: "js",
     quote: "'",
     getImportModule: (importName, moduleName) => `const ${importName} = require('${moduleName}');`,

--- a/src/utils/configTemplates/ts.ts
+++ b/src/utils/configTemplates/ts.ts
@@ -1,8 +1,8 @@
 import { ConfigTemplate } from ".";
-import { TESTPLANE_TS_CONFIG_NAME } from "../../constants/packageManagement";
+import { CONFIG_NAMES } from "../../constants/packageManagement";
 
 export const tsTemplate: ConfigTemplate = {
-    fileName: TESTPLANE_TS_CONFIG_NAME,
+    fileName: CONFIG_NAMES.TESTPLANE_TS,
     language: "ts",
     quote: '"',
     getImportModule: (importName, moduleName) => `import ${importName} from "${moduleName}";`,

--- a/src/utils/configTemplates/ts.ts
+++ b/src/utils/configTemplates/ts.ts
@@ -6,7 +6,7 @@ export const tsTemplate: ConfigTemplate = {
     language: "ts",
     quote: '"',
     getImportModule: (importName, moduleName) => `import ${importName} from "${moduleName}";`,
-    getExportConfig: config => `// @ts-ignore\nexport = ${config};\n`,
+    getExportConfig: config => `export default ${config};\n`,
 };
 
 export default tsTemplate;

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -85,7 +85,7 @@ describe("utils", () => {
 
     describe("packageNameFromPlugin", () => {
         describe("should trim suffix", () => {
-            ["/plugin", "/testplane"].forEach(suffix => {
+            ["/plugin", "/testplane", "/hermione"].forEach(suffix => {
                 it(suffix, () => {
                     const somePluginName = "html-reporter" + suffix;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -140,7 +140,11 @@ export const defineVariable = (config: TestplaneConfig, { name, value, isExpr }:
     return _.set(config, ["__variables", name], isExpr ? value : asString(value, quote));
 };
 
-export const addModule = (config: TestplaneConfig, variableName: string, moduleName = variableName): TestplaneConfig => {
+export const addModule = (
+    config: TestplaneConfig,
+    variableName: string,
+    moduleName = variableName,
+): TestplaneConfig => {
     return _.set(config, ["__modules", variableName], moduleName);
 };
 


### PR DESCRIPTION
## What is done
- returned back single quotes in fixtures (as it is not a part of code. Usually people use single quotes in js config)
- aligned `package-lock` to `package.json`
- fixed linter checks
- fixed fixture typo
- replaced `html-reporter/testplane` -> `html-reporter`
- returned `/hermione` suffix support in plugins (to keep backward compatibility as an API provider)
- abort on existing `.hermione.conf.js` / `.hermione.conf.ts` (since testplane@0 can use those)
- used `export default` instead of `export =` in typescript template (which is supported in testplane)

## TBD
- remove old unused plugins after rebranding the plugins themselves