### PR TITLE
fix(create-testplane): fix scripts test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 build-spec
 .DS_Store
+.idea

--- a/src/fsUtils.ts
+++ b/src/fsUtils.ts
@@ -123,4 +123,10 @@ export const writeJson = async (filePath: string, obj: Record<string, unknown>):
     return fs.promises.writeFile(filePath, JSON.stringify(obj, null, 4));
 };
 
-export default { exists, ensureDirectory, writeTestplaneConfig, writeTest, writeJson };
+export const readJson = async (filePath: string): Promise<Record<string, unknown>> => {
+    return new Promise(resolve => {
+        fs.readFile(filePath, "utf8", (_, data: string) => resolve(JSON.parse(data)));
+    });
+};
+
+export default { exists, ensureDirectory, writeTestplaneConfig, writeTest, writeJson, readJson };

--- a/src/package.ts
+++ b/src/package.ts
@@ -61,6 +61,10 @@ const initNodeProject = (dirPath: string, packageManager: PackageManager): Promi
         );
     });
 
+interface MinimalPackageJson {
+    scripts?: { [key: string]: string };
+}
+
 export const initApp = async (dirPath: string, extraQuestions: boolean): Promise<PackageManager> => {
     await fsUtils.ensureDirectory(dirPath);
 
@@ -77,6 +81,18 @@ export const initApp = async (dirPath: string, extraQuestions: boolean): Promise
     const isPackageJsonExist = await fsUtils.exists(path.resolve(dirPath, PACKAGE_JSON));
     if (!isPackageJsonExist) {
         await initNodeProject(dirPath, packageManager);
+    }
+
+    const packageJson: MinimalPackageJson = await fsUtils.readJson(path.resolve(dirPath, PACKAGE_JSON));
+
+    if (packageJson && (!packageJson?.scripts?.test || !isPackageJsonExist)) {
+        packageJson.scripts = {
+            ...(packageJson?.scripts || {}),
+            test: "testplane",
+            "test:gui": "testplane gui",
+        };
+
+        await fsUtils.writeJson(path.resolve(dirPath, PACKAGE_JSON), packageJson as Record<string, string>);
     }
 
     return packageManager;


### PR DESCRIPTION
By default we create package.json with
```json
"scripts": {    "test": "echo \"Error: no test specified\" && exit 1"  },
```
which is quite ironic.

I added scripts test and test:gui